### PR TITLE
Rollback python 3.9

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,10 +15,10 @@ jobs:
       with:
         timezone: UTC
 
-    - name: Set up Python 3.10
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: '3.10'
+        python-version: 3.9
 
     - name: Install Python dependencies
       run: |

--- a/README.md
+++ b/README.md
@@ -26,3 +26,9 @@ pip install .
 For speed, rather than use NC_000962.3 (i.e. H37Rv *M. tuberculosis*), we shall use SARS-CoV-2 and have created a fictious drug resistance catalogue, along with some `vcf` files and the expected outputs in `tests/`.
 
 These can be run with `pytest -vv`
+
+## Known issues
+
+1. When running with NextFlow, the output directory must be manually created beforehand due to how NextFlow creates projects interfering with paths.
+
+2. If the output directory specified already has a populated `mutations.csv` and/or `effects.csv`, if this gnomon run does not produce these files, their values will still be included in the `gnomon-out.json` if created.

--- a/gnomon/gnomon.py
+++ b/gnomon/gnomon.py
@@ -395,8 +395,9 @@ def populateEffects(
     #Return  the metadata dict to log later
     return {"WGS_PREDICTION_"+drug: phenotype[drug] for drug in resistanceCatalogue.catalogue.drugs}
     
-def getCSV(path: str, csv: str) -> None | pd.DataFrame:
-    '''Get the specified CSV from a specified path as a DataFrame
+def getCSV(path: str, csv: str):
+    '''Get the specified CSV from a specified path as a DataFrame.
+    Return type hinting removed due to union type for compatability with python 3.9
 
     Args:
         path (str): Path to the directory


### PR DESCRIPTION
Remove breaking changes with union type hinting to allow python 3.9 compatibility (for use with docker's ubuntu:20.04 image)